### PR TITLE
Only call read on SASL transport when byte buffer is empty

### DIFF
--- a/lib/impala/protocol/impala_sasl_client_transport.rb
+++ b/lib/impala/protocol/impala_sasl_client_transport.rb
@@ -31,7 +31,7 @@ module Thrift
     end
 
     def read(sz)
-      len, = @transport.read(SASL_PAYLOAD_LENGTH_BYTES).unpack('l>')
+      len, = @transport.read(SASL_PAYLOAD_LENGTH_BYTES).unpack('l>') if @rbuf.nil?
       sz = len if len && sz > len
       @index += sz
       ret = @rbuf.slice(@index - sz, sz) || Bytes.empty_byte_buffer


### PR DESCRIPTION
Thanks for adding SASL support to impala-ruby!  I needed to make a small change to avoid blocking when executing statements that have no results.  (The same check is in rbhive.)